### PR TITLE
feat: allow plugins to add reasons

### DIFF
--- a/thorplugin.go
+++ b/thorplugin.go
@@ -117,17 +117,13 @@ type Scanner interface {
 	// and Sigma rules.
 	ScanStructuredData(data []KeyValuePair)
 
+	// AddReason adds a reason to the element passed to the callback.
+	AddReason(reason thorlog.Reason)
+
 	Logger
 }
 
 type Logger interface {
-	// Log logs a notice, warning, or alert based on the score passed and the
-	// --notice / --warning / --alert thresholds passed to THOR.
-	//
-	// kv needs to be a number of key / value pairs, where each key must be a
-	// string, ordered as key1, value1, key2, value2, ...
-	Log(text string, reason string, score int64, kv ...any)
-
 	// Info logs an informational message.
 	//
 	// kv needs to be a number of key / value pairs, where each key must be a


### PR DESCRIPTION
Currently plugins can't really add reasons in a nice way; the only way to do so is via LogFinding, which is primitive. Instead, allow plugins to add a fully fledged reason to the current element.